### PR TITLE
Linkagem da API concluída

### DIFF
--- a/services/api.js
+++ b/services/api.js
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: "https://dadosabertos.camara.leg.br/swagger/api.html",
+});
+
+export default api;


### PR DESCRIPTION
Colocamos o axios e então colocamos o link para chamar a api de deputados.

Link: https://dadosabertos.camara.leg.br/swagger/api.html